### PR TITLE
Enable excluding properties from the excel sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ public class Employee {
         return name;
     }
     ...
+    //this column will not be presented in the excel sheet.
+    @NoSheetColumn()
+    private String socialSecurityNumber;
 }
 ```
 

--- a/src/main/java/io/github/millij/poi/ss/model/annotations/NoSheetColumn.java
+++ b/src/main/java/io/github/millij/poi/ss/model/annotations/NoSheetColumn.java
@@ -1,0 +1,28 @@
+package io.github.millij.poi.ss.model.annotations;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+
+/**
+ * Marker annotation that can be used to define a "type" for a sheet. The value of this annotation
+ * will be used to map the sheet of the workbook to this bean definition.
+ * 
+ * <p>
+ * Default value ("") indicates that the default sheet name to be used without any modifications,
+ * but it can be specified to non-empty value to specify different name.
+ * </p>
+ * 
+ * <p>
+ * Typically used when writing the java objects to the file.
+ * </p>
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface NoSheetColumn {
+
+
+}

--- a/src/main/java/io/github/millij/poi/util/Spreadsheet.java
+++ b/src/main/java/io/github/millij/poi/util/Spreadsheet.java
@@ -58,6 +58,8 @@ public final class Spreadsheet {
         // Fields
         Field[] fields = beanType.getDeclaredFields();
         for (Field f : fields) {
+            if(f.isAnnotationPresent(NoSheetColumn.class))
+                continue;
             String fieldName = f.getName();
             mapping.put(fieldName, fieldName);
 


### PR DESCRIPTION
In some cases we need to hide some columns from the end user. In such case we can add new annotation on that property in order the library will ignore it when writing the excel file