### PR TITLE
Indexing order of Headers at annotations to write

### DIFF
--- a/src/main/java/io/github/millij/poi/ss/model/annotations/SheetColumn.java
+++ b/src/main/java/io/github/millij/poi/ss/model/annotations/SheetColumn.java
@@ -26,6 +26,8 @@ public @interface SheetColumn {
      */
     String value() default "";
 
+    int index() default -1;
+
     /**
      * Setting this to <code>false</code> will enable the null check on the Column values, to ensure
      * non-null values for the field.

--- a/src/test/java/io/github/millij/bean/EmployeeIndexed.java
+++ b/src/test/java/io/github/millij/bean/EmployeeIndexed.java
@@ -1,0 +1,98 @@
+package io.github.millij.bean;
+
+import io.github.millij.poi.ss.model.annotations.Sheet;
+import io.github.millij.poi.ss.model.annotations.SheetColumn;
+
+
+@Sheet
+public class EmployeeIndexed {
+    private String id;
+    private String name;
+
+    @SheetColumn(value = "Age", index = 2)
+    private Integer age;
+
+    @SheetColumn(value = "Gender", index = 3)
+    private String gender;
+
+    @SheetColumn(value = "Height (mts)", index = 4)
+    private Double height;
+
+    @SheetColumn(value = "Address", index = 5)
+    private String address;
+
+
+    public EmployeeIndexed() {
+        // Default
+    }
+
+    public EmployeeIndexed(String id, String name, Integer age, String gender, Double height, String address) {
+        super();
+
+        this.id = id;
+        this.name = name;
+        this.age = age;
+        this.gender = gender;
+        this.height = height;
+        this.address = address;
+
+    }
+
+
+
+    @SheetColumn(value = "ID", index = 0)
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @SheetColumn(value = "Name", index = 1)
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getAge() {
+        return age;
+    }
+
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    public String getGender() {
+        return gender;
+    }
+
+    public void setGender(String gender) {
+        this.gender = gender;
+    }
+
+    public Double getHeight() {
+        return height;
+    }
+
+    public void setHeight(Double height) {
+        this.height = height;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    @Override
+    public String toString() {
+        return "Emp_indexed [id=" + id + ", name=" + name + ", age=" + age + ", gender=" + gender + ", height=" + height
+                + ", address=" + address + "]";
+    }
+}

--- a/src/test/java/io/github/millij/bean/EmployeeIndexed.java
+++ b/src/test/java/io/github/millij/bean/EmployeeIndexed.java
@@ -9,7 +9,7 @@ public class EmployeeIndexed {
     private String id;
     private String name;
 
-    @SheetColumn(value = "Age", index = 2)
+    @SheetColumn(value = "Age",index = 2)
     private Integer age;
 
     @SheetColumn(value = "Gender", index = 3)

--- a/src/test/java/io/github/millij/poi/ss/writer/IndexedHeadersWriterTest.java
+++ b/src/test/java/io/github/millij/poi/ss/writer/IndexedHeadersWriterTest.java
@@ -1,0 +1,44 @@
+package io.github.millij.poi.ss.writer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.github.millij.bean.Employee;
+import io.github.millij.bean.EmployeeIndexed;
+import io.github.millij.poi.ss.model.annotations.SheetColumn;
+import io.github.millij.poi.ss.writer.SpreadsheetWriter;
+import io.github.millij.poi.ss.writer.SpreadsheetWriterTest;
+
+
+public class IndexedHeadersWriterTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpreadsheetWriterTest.class);
+
+    private final String _path_test_output = "test-cases/output/";
+
+
+
+    @Test
+    public void test_write_xlsx_single_sheet() throws IOException {
+        final String filepath_output_file = _path_test_output.concat("indexed_header_writer_sample.xlsx");
+
+        // Excel Writer
+        LOGGER.info("test_write_xlsx_single_sheet :: Writing to file - {}", filepath_output_file);
+        SpreadsheetWriter gew = new SpreadsheetWriter(filepath_output_file);
+
+        // Employees
+        List<EmployeeIndexed> employees = new ArrayList<EmployeeIndexed>();
+        employees.add(new EmployeeIndexed("1", "foo", 12, "MALE", 1.68, "Chennai"));
+        employees.add(new EmployeeIndexed("2", "bar", 24, "MALE", 1.98, "Banglore"));
+        employees.add(new EmployeeIndexed("3", "foo bar", 10, "FEMALE", 2.0, "Kolkata"));
+
+        // Write
+        gew.addSheet(EmployeeIndexed.class, employees);
+        gew.write();
+    }
+
+}


### PR DESCRIPTION
Modified **Spreadsheet.getColumnNames( )** method.
Added new method **Spreadsheet.getIndexToPropertyMap( )**.
Modified exisitng method **getPropertyToColumnNameMap( )** to avoid the non-annotated methods in written sheet. **("tring")**
Added test-cases.