### PR TITLE
Read Spreadsheet rows as Map<String, Object>

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     // Test compile
     // ----------------------------------------------------------------------------------
 
+    testImplementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.19.0'
+    testImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.19.0'
+
     testImplementation group: 'junit', name: 'junit', version: '4.12'
 
 }

--- a/src/main/java/io/github/millij/poi/ss/handler/RowContentsAsMapHandler.java
+++ b/src/main/java/io/github/millij/poi/ss/handler/RowContentsAsMapHandler.java
@@ -1,0 +1,118 @@
+package io.github.millij.poi.ss.handler;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.github.millij.poi.util.Spreadsheet;
+
+
+public class RowContentsAsMapHandler extends AbstractSheetContentsHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RowContentsAsMapHandler.class);
+
+    private final RowListener<Map<String, Object>> listener;
+
+    private final int headerRowNum;
+    private final Map<String, String> headerCellRefsMap;
+
+    private final int lastRowNum;
+
+
+    // Constructors
+    // ------------------------------------------------------------------------
+
+    public RowContentsAsMapHandler(RowListener<Map<String, Object>> listener, int headerRowNum, int lastRowNum) {
+        super();
+
+        // init
+        this.listener = listener;
+
+        this.headerRowNum = headerRowNum;
+        this.headerCellRefsMap = new HashMap<>();
+
+        this.lastRowNum = lastRowNum;
+    }
+
+
+    // AbstractSheetContentsHandler Methods
+    // ------------------------------------------------------------------------
+
+    @Override
+    void beforeRowStart(final int rowNum) {
+        try {
+            // Row Callback
+            listener.beforeRow(rowNum);
+        } catch (Exception ex) {
+            String errMsg = String.format("Error calling #beforeRow callback  row - %d", rowNum);
+            LOGGER.error(errMsg, ex);
+        }
+    }
+
+
+    @Override
+    void afterRowEnd(final int rowNum, final Map<String, Object> rowDataMap) {
+        // Sanity Checks
+        if (Objects.isNull(rowDataMap) || rowDataMap.isEmpty()) {
+            LOGGER.debug("INVALID Row data Passed - Row #{}", rowNum);
+            return;
+        }
+
+        // Skip rows before Header ROW and after Last ROW
+        if (rowNum < headerRowNum || rowNum > lastRowNum) {
+            return;
+        }
+
+        // Process Header ROW
+        if (rowNum == headerRowNum) {
+            final Map<String, String> headerCellRefs = this.asHeaderNameToCellRefMap(rowDataMap);
+            headerCellRefsMap.putAll(headerCellRefs);
+            return;
+        }
+
+        // Check for Column Definitions before processing NON-Header ROWs
+
+        // Row As Bean
+        final Map<String, Object> rowBean = Spreadsheet.rowAsMap(headerCellRefsMap, rowDataMap);
+        if (Objects.isNull(rowBean)) {
+            LOGGER.debug("Unable to construct Row data Bean object - Row #{}", rowNum);
+            return;
+        }
+
+        // Row Callback
+        try {
+            listener.row(rowNum, rowBean);
+        } catch (Exception ex) {
+            String errMsg = String.format("Error calling #row callback  row - %d, bean - %s", rowNum, rowBean);
+            LOGGER.error(errMsg, ex);
+        }
+    }
+
+
+    // Private Methods
+    // ------------------------------------------------------------------------
+
+    private Map<String, String> asHeaderNameToCellRefMap(final Map<String, Object> headerRowData) {
+        // Sanity checks
+        if (Objects.isNull(headerRowData) || headerRowData.isEmpty()) {
+            return new HashMap<>();
+        }
+
+        // Get Bean Column definitions
+        final Map<String, String> headerCellRefs = new HashMap<String, String>();
+        for (final String colRef : headerRowData.keySet()) {
+            final Object header = headerRowData.get(colRef);
+
+            final String headerName = Objects.isNull(header) ? "" : String.valueOf(header);
+            headerCellRefs.put(headerName, colRef);
+        }
+
+        LOGGER.debug("Header Name to Cell Refs : {}", headerCellRefs);
+        return headerCellRefs;
+    }
+
+
+}

--- a/src/main/java/io/github/millij/poi/ss/reader/AbstractSpreadsheetReader.java
+++ b/src/main/java/io/github/millij/poi/ss/reader/AbstractSpreadsheetReader.java
@@ -2,6 +2,7 @@ package io.github.millij.poi.ss.reader;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,6 +69,36 @@ abstract class AbstractSpreadsheetReader implements SpreadsheetReader {
 
         // Result
         final List<T> beans = beanCollector.getBeans();
+        return beans;
+    }
+
+
+    //
+    // Read to Map
+
+    @Override
+    public List<Map<String, Object>> read(final InputStream is) throws SpreadsheetReadException {
+        // Row Collector
+        final RowBeanCollector<Map<String, Object>> beanCollector = new RowBeanCollector<>();
+
+        // Read with callback to fill list
+        this.read(is, beanCollector);
+
+        // Result
+        final List<Map<String, Object>> beans = beanCollector.getBeans();
+        return beans;
+    }
+
+    @Override
+    public List<Map<String, Object>> read(final InputStream is, final int sheetNo) throws SpreadsheetReadException {
+        // Row Collector
+        final RowBeanCollector<Map<String, Object>> beanCollector = new RowBeanCollector<>();
+
+        // Read with callback to fill list
+        this.read(is, sheetNo, beanCollector);
+
+        // Result
+        final List<Map<String, Object>> beans = beanCollector.getBeans();
         return beans;
     }
 

--- a/src/main/java/io/github/millij/poi/ss/reader/SpreadsheetReader.java
+++ b/src/main/java/io/github/millij/poi/ss/reader/SpreadsheetReader.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 
 import io.github.millij.poi.SpreadsheetReadException;
 import io.github.millij.poi.ss.handler.RowListener;
@@ -193,6 +194,59 @@ public interface SpreadsheetReader {
             throw new SpreadsheetReadException(errMsg, ex);
         }
     }
+
+
+    //
+    // Read to Map
+
+    /**
+     * Reads the spreadsheet file as Generic {@link Map} beans. Note that only the requested sheet (sheet numbers are
+     * indexed from 0) will be read.
+     * 
+     * @param is {@link InputStream} of the spreadsheet file
+     * @param listener Custom {@link RowListener} implementation for row data callbacks.
+     * 
+     * @throws SpreadsheetReadException when the file data is not readable or row data to bean mapping failed.
+     */
+    void read(InputStream is, RowListener<Map<String, Object>> listener) throws SpreadsheetReadException;
+
+    /**
+     * Reads the spreadsheet file as Generic {@link Map} beans. Note that only the requested sheet (sheet numbers are
+     * indexed from 0) will be read.
+     * 
+     * @param is {@link InputStream} of the spreadsheet file
+     * @param sheetNo index of the Sheet to be read (index starts from 1)
+     * @param listener Custom {@link RowListener} implementation for row data callbacks.
+     * 
+     * @throws SpreadsheetReadException when the file data is not readable or row data to bean mapping failed.
+     */
+    void read(InputStream is, int sheetNo, RowListener<Map<String, Object>> listener) throws SpreadsheetReadException;
+
+
+    /**
+     * Reads the spreadsheet file as Generic {@link Map} beans. Note that only the requested sheet (sheet numbers are
+     * indexed from 0) will be read.
+     * 
+     * @param is {@link InputStream} of the spreadsheet file
+     * 
+     * @return a {@link List} of {@link Map} objects
+     * 
+     * @throws SpreadsheetReadException when the file data is not readable or row data to bean mapping failed.
+     */
+    List<Map<String, Object>> read(InputStream is) throws SpreadsheetReadException;
+
+    /**
+     * Reads the spreadsheet file as Generic {@link Map} beans. Note that only the requested sheet (sheet numbers are
+     * indexed from 0) will be read.
+     * 
+     * @param is {@link InputStream} of the spreadsheet file
+     * @param sheetNo index of the Sheet to be read (index starts from 1)
+     * 
+     * @return a {@link List} of {@link Map} objects
+     * 
+     * @throws SpreadsheetReadException when the file data is not readable or row data to bean mapping failed.
+     */
+    List<Map<String, Object>> read(InputStream is, int sheetNo) throws SpreadsheetReadException;
 
 
 }

--- a/src/main/java/io/github/millij/poi/ss/reader/XlsReader.java
+++ b/src/main/java/io/github/millij/poi/ss/reader/XlsReader.java
@@ -81,7 +81,6 @@ public class XlsReader extends AbstractSpreadsheetReader {
             LOGGER.error(errMsg, ex);
             throw new SpreadsheetReadException(errMsg, ex);
         }
-
     }
 
     @Override
@@ -110,13 +109,89 @@ public class XlsReader extends AbstractSpreadsheetReader {
 
 
     //
+    // Read to Map
+
+    @Override
+    public void read(final InputStream is, final RowListener<Map<String, Object>> listener)
+            throws SpreadsheetReadException {
+        try {
+            final HSSFWorkbook wb = new HSSFWorkbook(is);
+            final int sheetCount = wb.getNumberOfSheets();
+            LOGGER.debug("Total no. of sheets found in HSSFWorkbook : #{}", sheetCount);
+
+            // Iterate over sheets
+            for (int i = 0; i < sheetCount; i++) {
+                final HSSFSheet sheet = wb.getSheetAt(i);
+                LOGGER.debug("Processing HSSFSheet at No. : {}", i);
+
+                // Process Sheet
+                this.processSheet(sheet, listener);
+            }
+
+            // Close workbook
+            wb.close();
+        } catch (Exception ex) {
+            String errMsg = String.format("Error reading HSSFSheet, to Map : %s", ex.getMessage());
+            LOGGER.error(errMsg, ex);
+            throw new SpreadsheetReadException(errMsg, ex);
+        }
+    }
+
+    @Override
+    public void read(final InputStream is, final int sheetNo, final RowListener<Map<String, Object>> listener)
+            throws SpreadsheetReadException {
+        try {
+            final HSSFWorkbook wb = new HSSFWorkbook(is);
+            final HSSFSheet sheet = wb.getSheetAt(sheetNo - 1); // subtract 1 as Workbook follows 0-based index
+
+            // Process Sheet
+            this.processSheet(sheet, listener);
+
+            // Close workbook
+            wb.close();
+        } catch (Exception ex) {
+            String errMsg = String.format("Error reading sheet %d, to Map : %s", sheetNo, ex.getMessage());
+            LOGGER.error(errMsg, ex);
+            throw new SpreadsheetReadException(errMsg, ex);
+        }
+    }
+
+
+    //
     // Protected Methods
     // ------------------------------------------------------------------------
+
+    protected void processSheet(final HSSFSheet sheet, final RowListener<Map<String, Object>> eventHandler) {
+        // Header column - name mapping
+        final HSSFRow headerRowObj = sheet.getRow(headerRowIdx);
+        final Map<String, String> headerCellRefsMap = this.asHeaderNameToCellRefMap(headerRowObj, false);
+
+        final Iterator<Row> rows = sheet.rowIterator();
+        while (rows.hasNext()) {
+            // Process Row Data
+            final HSSFRow row = (HSSFRow) rows.next();
+            final int rowNum = row.getRowNum();
+
+            // Skip rows before Header ROW and after Last ROW
+            if (rowNum < headerRowIdx || rowNum > lastRowIdx) {
+                continue;
+            }
+
+            final Map<String, Object> rowDataMap = this.extractRowDataAsMap(row);
+            if (rowDataMap == null || rowDataMap.isEmpty()) {
+                continue;
+            }
+
+            // Row data as Bean
+            final Map<String, Object> rowBean = Spreadsheet.rowAsMap(headerCellRefsMap, rowDataMap);
+            eventHandler.row(rowNum, rowBean);
+        }
+    }
 
     protected <T> void processSheet(final Class<T> beanClz, final HSSFSheet sheet, final RowListener<T> eventHandler) {
         // Header column - name mapping
         final HSSFRow headerRowObj = sheet.getRow(headerRowIdx);
-        final Map<String, String> headerCellRefsMap = this.asHeaderNameToCellRefMap(headerRowObj);
+        final Map<String, String> headerCellRefsMap = this.asHeaderNameToCellRefMap(headerRowObj, true);
 
         // Bean Properties - column name mapping
         final Map<String, Column> propColumnMap = Spreadsheet.getPropertyToColumnDefMap(beanClz);
@@ -147,7 +222,7 @@ public class XlsReader extends AbstractSpreadsheetReader {
     // Private Methods
     // ------------------------------------------------------------------------
 
-    private Map<String, String> asHeaderNameToCellRefMap(final HSSFRow headerRow) {
+    private Map<String, String> asHeaderNameToCellRefMap(final HSSFRow headerRow, final boolean normalizeHeaderName) {
         // Sanity checks
         if (Objects.isNull(headerRow)) {
             return new HashMap<>();
@@ -164,9 +239,9 @@ public class XlsReader extends AbstractSpreadsheetReader {
             // Cell Value
             final Object header = this.getCellValue(cell);
 
-            final String headerName = Objects.isNull(header) ? "" : String.valueOf(header);
-            final String normalHeaderName = Spreadsheet.normalize(headerName);
-            headerCellRefs.put(normalHeaderName, cellColRef);
+            final String rawHeaderName = Objects.isNull(header) ? "" : String.valueOf(header);
+            final String headerName = normalizeHeaderName ? Spreadsheet.normalize(rawHeaderName) : rawHeaderName;
+            headerCellRefs.put(headerName, cellColRef);
         }
 
         return headerCellRefs;

--- a/src/main/java/io/github/millij/poi/util/Spreadsheet.java
+++ b/src/main/java/io/github/millij/poi/util/Spreadsheet.java
@@ -206,6 +206,37 @@ public final class Spreadsheet {
     // Write to Bean :: from Row data
     // ------------------------------------------------------------------------
 
+    public static Map<String, Object> rowAsMap(final Map<String, String> headerCellRefsMap,
+            final Map<String, Object> rowDataMap) {
+        //
+        try {
+            // Create new Instance
+            final Map<String, Object> beanMap = new HashMap<String, Object>();
+
+            for (final String propColName : headerCellRefsMap.keySet()) {
+                // Get the Header Cell Ref
+                final String propCellRef = headerCellRefsMap.get(propColName);
+                if (Objects.isNull(propCellRef) || propCellRef.isBlank()) {
+                    continue;
+                }
+
+                // Property Value and Format
+                final Object propValue = rowDataMap.get(propCellRef);
+
+                // set
+                beanMap.put(propColName, propValue);
+            }
+
+            return beanMap;
+        } catch (Exception ex) {
+            String errMsg = String.format("Error while creating Row Map, from - %s", rowDataMap);
+            LOGGER.error(errMsg, ex);
+        }
+
+        return null;
+    }
+
+
     public static <T> T rowAsBean(Class<T> beanClz, Map<String, Column> propColumnMap,
             Map<String, String> headerCellRefsMap, Map<String, Object> rowDataMap) {
         // Sanity checks

--- a/src/test/java/io/github/millij/poi/ss/reader/XlsReaderTest.java
+++ b/src/test/java/io/github/millij/poi/ss/reader/XlsReaderTest.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -169,12 +170,37 @@ public class XlsReaderTest {
                 employees.add(employee);
                 LOGGER.info("test_read_xls_single_sheet_with_callback :: Output - {}", employee);
 
+                // ?
             }
 
         });
 
         Assert.assertNotNull(employees);
         Assert.assertTrue(employees.size() > 0);
+    }
+
+
+    // Read to Map
+
+    @Test
+    public void test_read_xlsx_as_Map() throws SpreadsheetReadException, FileNotFoundException {
+        // Excel Reader
+        LOGGER.info("test_read_xlsx_as_Map :: Reading file - {}", _filepath_xls_single_sheet);
+
+        // File
+        final File xlsxFile = new File(_filepath_xls_single_sheet);
+
+        // Reader
+        final XlsReader reader = new XlsReader();
+
+        List<Map<String, Object>> employees = reader.read(new FileInputStream(xlsxFile), 1);
+        Assert.assertNotNull(employees);
+        Assert.assertTrue(employees.size() > 0);
+
+        for (Map<String, Object> emp : employees) {
+            LOGGER.info("test_read_xlsx_as_Map :: Output - {}", emp);
+        }
+
     }
 
 }

--- a/src/test/java/io/github/millij/poi/ss/reader/XlsxReaderTest.java
+++ b/src/test/java/io/github/millij/poi/ss/reader/XlsxReaderTest.java
@@ -7,11 +7,11 @@ import java.io.InputStream;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -181,25 +181,25 @@ public class XlsxReaderTest {
 
     // Read to Map
 
-
-    @Ignore
     @Test
-    public void test_read_xlsx_as_Map() throws FileNotFoundException {
+    public void test_read_xlsx_as_Map() throws SpreadsheetReadException, FileNotFoundException {
         // Excel Reader
         LOGGER.info("test_read_xlsx_as_Map :: Reading file - {}", _filepath_xlsx_single_sheet);
 
-        /*
+        // File
+        final File xlsxFile = new File(_filepath_xlsx_single_sheet);
+
         // Reader
         final XlsxReader reader = new XlsxReader();
 
-        List<Map<String, Object>> employees = reader.readAsMap(new File(_filepath_xlsx_single_sheet), 1);
+        List<Map<String, Object>> employees = reader.read(new FileInputStream(xlsxFile), 1);
         Assert.assertNotNull(employees);
         Assert.assertTrue(employees.size() > 0);
 
         for (Map<String, Object> emp : employees) {
             LOGGER.info("test_read_xlsx_single_sheet :: Output - {}", emp);
         }
-        */
+
     }
 
 

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -1,0 +1,15 @@
+# Properties
+
+# Root Logger Config
+rootLogger.level=INFO
+rootLogger.appenderRefs=console
+rootLogger.appenderRef.console.ref=STDOUT
+
+# Appenders Config
+appenders=console
+
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+


### PR DESCRIPTION
Existing read API - Reads the rows as custom bean
```
SpreadsheetReader {
    <T> List<T> read(Class<T> beanClz, ...);
}
```

New addition
```
SpreadsheetReader {
    ...
    
    // Read to Map (KEY is the Header name and VALUE is the Cell value)
    List<Map<String, Object>> read(...);

}
```

